### PR TITLE
enable title search in items API

### DIFF
--- a/backend/routes/api/items.js
+++ b/backend/routes/api/items.js
@@ -7,10 +7,10 @@ var auth = require("../auth");
 const { sendEvent } = require("../../lib/event");
 
 // Preload item objects on routes with ':item'
-router.param("item", function(req, res, next, slug) {
+router.param("item", function (req, res, next, slug) {
   Item.findOne({ slug: slug })
     .populate("seller")
-    .then(function(item) {
+    .then(function (item) {
       if (!item) {
         return res.sendStatus(404);
       }
@@ -22,9 +22,9 @@ router.param("item", function(req, res, next, slug) {
     .catch(next);
 });
 
-router.param("comment", function(req, res, next, id) {
+router.param("comment", function (req, res, next, id) {
   Comment.findById(id)
-    .then(function(comment) {
+    .then(function (comment) {
       if (!comment) {
         return res.sendStatus(404);
       }
@@ -36,7 +36,7 @@ router.param("comment", function(req, res, next, id) {
     .catch(next);
 });
 
-router.get("/", auth.optional, function(req, res, next) {
+router.get("/", auth.optional, function (req, res, next) {
   var query = {};
   var limit = 100;
   var offset = 0;
@@ -53,11 +53,15 @@ router.get("/", auth.optional, function(req, res, next) {
     query.tagList = { $in: [req.query.tag] };
   }
 
+  if (typeof req.query.title !== "undefined") {
+    query.title = req.query.title;
+  }
+
   Promise.all([
     req.query.seller ? User.findOne({ username: req.query.seller }) : null,
     req.query.favorited ? User.findOne({ username: req.query.favorited }) : null
   ])
-    .then(function(results) {
+    .then(function (results) {
       var seller = results[0];
       var favoriter = results[1];
 
@@ -79,13 +83,13 @@ router.get("/", auth.optional, function(req, res, next) {
           .exec(),
         Item.count(query).exec(),
         req.payload ? User.findById(req.payload.id) : null
-      ]).then(async function(results) {
+      ]).then(async function (results) {
         var items = results[0];
         var itemsCount = results[1];
         var user = results[2];
         return res.json({
           items: await Promise.all(
-            items.map(async function(item) {
+            items.map(async function (item) {
               item.seller = await User.findById(item.seller);
               return item.toJSONFor(user);
             })
@@ -97,7 +101,7 @@ router.get("/", auth.optional, function(req, res, next) {
     .catch(next);
 });
 
-router.get("/feed", auth.required, function(req, res, next) {
+router.get("/feed", auth.required, function (req, res, next) {
   var limit = 20;
   var offset = 0;
 
@@ -109,7 +113,7 @@ router.get("/feed", auth.required, function(req, res, next) {
     offset = req.query.offset;
   }
 
-  User.findById(req.payload.id).then(function(user) {
+  User.findById(req.payload.id).then(function (user) {
     if (!user) {
       return res.sendStatus(401);
     }
@@ -122,12 +126,12 @@ router.get("/feed", auth.required, function(req, res, next) {
         .exec(),
       Item.count({ seller: { $in: user.following } })
     ])
-      .then(function(results) {
+      .then(function (results) {
         var items = results[0];
         var itemsCount = results[1];
 
         return res.json({
-          items: items.map(function(item) {
+          items: items.map(function (item) {
             return item.toJSONFor(user);
           }),
           itemsCount: itemsCount
@@ -137,9 +141,9 @@ router.get("/feed", auth.required, function(req, res, next) {
   });
 });
 
-router.post("/", auth.required, function(req, res, next) {
+router.post("/", auth.required, function (req, res, next) {
   User.findById(req.payload.id)
-    .then(function(user) {
+    .then(function (user) {
       if (!user) {
         return res.sendStatus(401);
       }
@@ -148,7 +152,7 @@ router.post("/", auth.required, function(req, res, next) {
 
       item.seller = user;
 
-      return item.save().then(function() {
+      return item.save().then(function () {
         sendEvent('item_created', { item: req.body.item })
         return res.json({ item: item.toJSONFor(user) });
       });
@@ -157,12 +161,12 @@ router.post("/", auth.required, function(req, res, next) {
 });
 
 // return a item
-router.get("/:item", auth.optional, function(req, res, next) {
+router.get("/:item", auth.optional, function (req, res, next) {
   Promise.all([
     req.payload ? User.findById(req.payload.id) : null,
     req.item.populate("seller").execPopulate()
   ])
-    .then(function(results) {
+    .then(function (results) {
       var user = results[0];
 
       return res.json({ item: req.item.toJSONFor(user) });
@@ -171,8 +175,8 @@ router.get("/:item", auth.optional, function(req, res, next) {
 });
 
 // update item
-router.put("/:item", auth.required, function(req, res, next) {
-  User.findById(req.payload.id).then(function(user) {
+router.put("/:item", auth.required, function (req, res, next) {
+  User.findById(req.payload.id).then(function (user) {
     if (req.item.seller._id.toString() === req.payload.id.toString()) {
       if (typeof req.body.item.title !== "undefined") {
         req.item.title = req.body.item.title;
@@ -192,7 +196,7 @@ router.put("/:item", auth.required, function(req, res, next) {
 
       req.item
         .save()
-        .then(function(item) {
+        .then(function (item) {
           return res.json({ item: item.toJSONFor(user) });
         })
         .catch(next);
@@ -203,15 +207,15 @@ router.put("/:item", auth.required, function(req, res, next) {
 });
 
 // delete item
-router.delete("/:item", auth.required, function(req, res, next) {
+router.delete("/:item", auth.required, function (req, res, next) {
   User.findById(req.payload.id)
-    .then(function(user) {
+    .then(function (user) {
       if (!user) {
         return res.sendStatus(401);
       }
 
       if (req.item.seller._id.toString() === req.payload.id.toString()) {
-        return req.item.remove().then(function() {
+        return req.item.remove().then(function () {
           return res.sendStatus(204);
         });
       } else {
@@ -222,17 +226,17 @@ router.delete("/:item", auth.required, function(req, res, next) {
 });
 
 // Favorite an item
-router.post("/:item/favorite", auth.required, function(req, res, next) {
+router.post("/:item/favorite", auth.required, function (req, res, next) {
   var itemId = req.item._id;
 
   User.findById(req.payload.id)
-    .then(function(user) {
+    .then(function (user) {
       if (!user) {
         return res.sendStatus(401);
       }
 
-      return user.favorite(itemId).then(function() {
-        return req.item.updateFavoriteCount().then(function(item) {
+      return user.favorite(itemId).then(function () {
+        return req.item.updateFavoriteCount().then(function (item) {
           return res.json({ item: item.toJSONFor(user) });
         });
       });
@@ -241,17 +245,17 @@ router.post("/:item/favorite", auth.required, function(req, res, next) {
 });
 
 // Unfavorite an item
-router.delete("/:item/favorite", auth.required, function(req, res, next) {
+router.delete("/:item/favorite", auth.required, function (req, res, next) {
   var itemId = req.item._id;
 
   User.findById(req.payload.id)
-    .then(function(user) {
+    .then(function (user) {
       if (!user) {
         return res.sendStatus(401);
       }
 
-      return user.unfavorite(itemId).then(function() {
-        return req.item.updateFavoriteCount().then(function(item) {
+      return user.unfavorite(itemId).then(function () {
+        return req.item.updateFavoriteCount().then(function (item) {
           return res.json({ item: item.toJSONFor(user) });
         });
       });
@@ -260,9 +264,9 @@ router.delete("/:item/favorite", auth.required, function(req, res, next) {
 });
 
 // return an item's comments
-router.get("/:item/comments", auth.optional, function(req, res, next) {
+router.get("/:item/comments", auth.optional, function (req, res, next) {
   Promise.resolve(req.payload ? User.findById(req.payload.id) : null)
-    .then(function(user) {
+    .then(function (user) {
       return req.item
         .populate({
           path: "comments",
@@ -276,9 +280,9 @@ router.get("/:item/comments", auth.optional, function(req, res, next) {
           }
         })
         .execPopulate()
-        .then(function(item) {
+        .then(function (item) {
           return res.json({
-            comments: req.item.comments.map(function(comment) {
+            comments: req.item.comments.map(function (comment) {
               return comment.toJSONFor(user);
             })
           });
@@ -288,9 +292,9 @@ router.get("/:item/comments", auth.optional, function(req, res, next) {
 });
 
 // create a new comment
-router.post("/:item/comments", auth.required, function(req, res, next) {
+router.post("/:item/comments", auth.required, function (req, res, next) {
   User.findById(req.payload.id)
-    .then(function(user) {
+    .then(function (user) {
       if (!user) {
         return res.sendStatus(401);
       }
@@ -299,10 +303,10 @@ router.post("/:item/comments", auth.required, function(req, res, next) {
       comment.item = req.item;
       comment.seller = user;
 
-      return comment.save().then(function() {
+      return comment.save().then(function () {
         req.item.comments = req.item.comments.concat([comment]);
 
-        return req.item.save().then(function(item) {
+        return req.item.save().then(function (item) {
           res.json({ comment: comment.toJSONFor(user) });
         });
       });
@@ -310,7 +314,7 @@ router.post("/:item/comments", auth.required, function(req, res, next) {
     .catch(next);
 });
 
-router.delete("/:item/comments/:comment", auth.required, function(
+router.delete("/:item/comments/:comment", auth.required, function (
   req,
   res,
   next
@@ -324,7 +328,7 @@ router.delete("/:item/comments/:comment", auth.required, function(
           .remove()
           .exec()
       )
-      .then(function() {
+      .then(function () {
         res.sendStatus(204);
       });
   } else {


### PR DESCRIPTION
# Description

Allows for `title` query param to be passed into the GET `/items` list API.  This allows for a database search against the items with a matching title and allows users to search more effectively.